### PR TITLE
Fix wieldmesh transparency

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -1158,9 +1158,6 @@ MapBlockMesh::MapBlockMesh(MeshMakeData *data, v3s16 camera_offset):
 				material.MaterialType = m_shdrsrc->getShaderInfo(
 						p.layer.shader_id).material;
 				p.layer.applyMaterialOptionsWithShaders(material);
-				if (p.layer.normal_texture)
-					material.setTexture(1, p.layer.normal_texture);
-				material.setTexture(2, p.layer.flags_texture);
 			} else {
 				p.layer.applyMaterialOptions(material);
 			}
@@ -1263,12 +1260,6 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 
 		const FrameSpec &animation_frame = (*tile.frames)[frame];
 		buf->getMaterial().setTexture(0, animation_frame.texture);
-		if (m_enable_shaders) {
-			if (animation_frame.normal_texture)
-				buf->getMaterial().setTexture(1,
-					animation_frame.normal_texture);
-			buf->getMaterial().setTexture(2, animation_frame.flags_texture);
-		}
 	}
 
 	// Day-night transition

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -176,8 +176,6 @@ struct FrameSpec
 
 	u32 texture_id = 0;
 	video::ITexture *texture = nullptr;
-	video::ITexture *normal_texture = nullptr;
-	video::ITexture *flags_texture = nullptr;
 };
 
 #define MAX_TILE_LAYERS 2
@@ -263,11 +261,8 @@ struct TileLayer
 	// Ordered for size, please do not reorder
 
 	video::ITexture *texture = nullptr;
-	video::ITexture *normal_texture = nullptr;
-	video::ITexture *flags_texture = nullptr;
 
 	u32 shader_id = 0;
-
 	u32 texture_id = 0;
 
 	u16 animation_frame_length_ms = 0;

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -41,15 +41,13 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #define MAX_EXTRUSION_MESH_RESOLUTION 512
 
 /*!
- * Applies overlays, textures and optionally materials to the given mesh and
+ * Applies overlays, textures and materials to the given mesh and
  * extracts tile colors for colorization.
- * \param mattype overrides the buffer's material type, but can also
- * be NULL to leave the original material.
  * \param colors returns the colors of the mesh buffers in the mesh.
  */
-static void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
-		bool set_material, const video::E_MATERIAL_TYPE *mattype,
-		std::vector<ItemPartColor> *colors);
+static void postProcessCubeMesh(scene::SMesh *mesh, const ContentFeatures &f,
+	IShaderSource *shader_source, std::string const &shader_name,
+	std::vector<ItemPartColor> *colors);
 
 static scene::IMesh *createExtrusionMesh(int resolution_x, int resolution_y)
 {
@@ -240,18 +238,6 @@ WieldMeshSceneNode::~WieldMeshSceneNode()
 		g_extrusion_mesh_cache = nullptr;
 }
 
-void WieldMeshSceneNode::setCube(const ContentFeatures &f,
-			v3f wield_scale)
-{
-	scene::IMesh *cubemesh = g_extrusion_mesh_cache->createCube();
-	scene::SMesh *copy = cloneMesh(cubemesh);
-	cubemesh->drop();
-	postProcessNodeMesh(copy, f, true, &m_material_type, &m_colors);
-	changeToMesh(copy);
-	copy->drop();
-	m_meshnode->setScale(wield_scale * WIELD_SCALE_FACTOR);
-}
-
 void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 	const std::string &overlay_name, v3f wield_scale, ITextureSource *tsrc,
 	u8 num_frames)
@@ -314,7 +300,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 	}
 }
 
-scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<ItemPartColor> *colors, const ContentFeatures &f)
+static scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<ItemPartColor> *colors, const ContentFeatures &f, std::string const shader_name = {})
 {
 	MeshMakeData mesh_make_data(client, false);
 	MeshCollector collector;
@@ -332,6 +318,7 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 	}
 	gen.renderSingle(id, param2);
 
+	IShaderSource *shader_source = shader_name.empty() ? nullptr : client->getShaderSource();
 	colors->clear();
 	scene::SMesh *mesh = new scene::SMesh();
 	for (auto &prebuffers : collector.prebuffers)
@@ -345,7 +332,14 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 			}
 			scene::SMeshBuffer *buf = new scene::SMeshBuffer();
 			buf->Material.setTexture(0, p.layer.texture);
-			p.layer.applyMaterialOptions(buf->Material);
+			if (!shader_name.empty()) {
+				auto shader_id = shader_source->getShader(shader_name, (MaterialType)p.layer.material_type, f.drawtype);
+				buf->Material.MaterialType = shader_source->getShaderInfo(shader_id).material;
+				p.layer.applyMaterialOptionsWithShaders(buf->Material);
+			} else {
+				p.layer.applyMaterialOptions(buf->Material);
+			}
+			buf->Material.MaterialTypeParam = 0.0f;
 			mesh->addMeshBuffer(buf);
 			buf->append(&p.vertices[0], p.vertices.size(),
 					&p.indices[0], p.indices.size());
@@ -420,12 +414,19 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		}
 		case NDT_NORMAL:
 		case NDT_ALLFACES:
-		case NDT_LIQUID:
-			setCube(f, def.wield_scale);
+		case NDT_LIQUID: {
+			scene::IMesh *cubemesh = g_extrusion_mesh_cache->createCube();
+			scene::SMesh *copy = cloneMesh(cubemesh);
+			cubemesh->drop();
+			postProcessCubeMesh(copy, f, shdrsrc, "object_shader", &m_colors);
+			changeToMesh(copy);
+			copy->drop();
+			m_meshnode->setScale(def.wield_scale * WIELD_SCALE_FACTOR);
 			break;
+		}
 		default:
 			// Render non-trivial drawtypes like the actual node
-			mesh = createSpecialNodeMesh(client, id, &m_colors, f);
+			mesh = createSpecialNodeMesh(client, id, &m_colors, f, "object_shader");
 			changeToMesh(mesh);
 			mesh->drop();
 			m_meshnode->setScale(
@@ -437,8 +438,6 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		u32 material_count = m_meshnode->getMaterialCount();
 		for (u32 i = 0; i < material_count; ++i) {
 			video::SMaterial &material = m_meshnode->getMaterial(i);
-			material.MaterialType = m_material_type;
-			material.MaterialTypeParam = 0.5f;
 			material.setFlag(video::EMF_BACK_FACE_CULLING, cull_backface);
 			material.setFlag(video::EMF_BILINEAR_FILTER, m_bilinear_filter);
 			material.setFlag(video::EMF_TRILINEAR_FILTER, m_trilinear_filter);
@@ -523,6 +522,7 @@ void WieldMeshSceneNode::changeToMesh(scene::IMesh *mesh)
 	m_meshnode->setVisible(true);
 }
 
+// Only used for inventory images
 void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 {
 	ITextureSource *tsrc = client->getTextureSource();
@@ -570,7 +570,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			} else
 				scaleMesh(mesh, v3f(1.2, 1.2, 1.2));
 			// add overlays
-			postProcessNodeMesh(mesh, f, false, nullptr, &result->buffer_colors);
+			postProcessCubeMesh(mesh, f, nullptr, {}, &result->buffer_colors);
 			if (f.drawtype == NDT_ALLFACES)
 				scaleMesh(mesh, v3f(f.visual_scale));
 			break;
@@ -664,8 +664,8 @@ scene::SMesh *getExtrudedMesh(ITextureSource *tsrc,
 	return mesh;
 }
 
-static  void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
-	bool set_material, const video::E_MATERIAL_TYPE *mattype,
+static void postProcessCubeMesh(scene::SMesh *mesh, const ContentFeatures &f,
+	IShaderSource *shader_source, std::string const &shader_name,
 	std::vector<ItemPartColor> *colors)
 {
 	u32 mc = mesh->getMeshBufferCount();
@@ -693,11 +693,14 @@ static  void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				(*colors)[i] = ItemPartColor(layer->has_color, layer->color);
 			}
 			video::SMaterial &material = buf->getMaterial();
-			if (set_material)
+			if (shader_source && !shader_name.empty()) {
+				auto shader_id = shader_source->getShader(shader_name, (MaterialType)layer->material_type, NDT_ALLFACES);
+				material.MaterialType = shader_source->getShaderInfo(shader_id).material;
+				layer->applyMaterialOptionsWithShaders(material);
+			} else {
 				layer->applyMaterialOptions(material);
-			if (mattype) {
-				material.MaterialType = *mattype;
 			}
+			material.MaterialTypeParam = 0.0f;
 			if (layer->animation_frame_count > 1) {
 				const FrameSpec &animation_frame = (*layer->frames)[0];
 				material.setTexture(0, animation_frame.texture);

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -328,7 +328,6 @@ scene::SMesh *createSpecialNodeMesh(Client *client, content_t id, std::vector<It
 			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
 				const FrameSpec &frame = (*p.layer.frames)[0];
 				p.layer.texture = frame.texture;
-				p.layer.normal_texture = frame.normal_texture;
 			}
 			for (video::S3DVertex &v : p.vertices) {
 				v.Color.setAlpha(255);
@@ -694,16 +693,6 @@ void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f,
 				material.setTexture(0, animation_frame.texture);
 			} else {
 				material.setTexture(0, layer->texture);
-			}
-			if (use_shaders) {
-				if (layer->normal_texture) {
-					if (layer->animation_frame_count > 1) {
-						const FrameSpec &animation_frame = (*layer->frames)[0];
-						material.setTexture(1, animation_frame.normal_texture);
-					} else
-						material.setTexture(1, layer->normal_texture);
-				}
-				material.setTexture(2, layer->flags_texture);
 			}
 			if (apply_scale && tile->world_aligned) {
 				u32 n = buf->getVertexCount();

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -130,14 +130,3 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result);
 
 scene::SMesh *getExtrudedMesh(ITextureSource *tsrc, const std::string &imagename,
 		const std::string &overlay_name);
-
-/*!
- * Applies overlays, textures and optionally materials to the given mesh and
- * extracts tile colors for colorization.
- * \param mattype overrides the buffer's material type, but can also
- * be NULL to leave the original material.
- * \param colors returns the colors of the mesh buffers in the mesh.
- */
-void postProcessNodeMesh(scene::SMesh *mesh, const ContentFeatures &f, bool use_shaders,
-		bool set_material, const video::E_MATERIAL_TYPE *mattype,
-		std::vector<ItemPartColor> *colors, bool apply_scale = false);

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -909,8 +909,6 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 	if (!tile.world_aligned)
 		layer->scale = 1;
 
-	layer->flags_texture = tsrc->getShaderFlagsTexture(layer->normal_texture ? true : false);
-
 	// Material flags
 	layer->material_flags = 0;
 	if (backface_culling)
@@ -958,9 +956,6 @@ static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 					layer->texture->getOriginalSize(), i);
 
 			frame.texture = tsrc->getTextureForMesh(os.str(), &frame.texture_id);
-			if (layer->normal_texture)
-				frame.normal_texture = tsrc->getNormalTexture(os.str());
-			frame.flags_texture = layer->flags_texture;
 			(*layer->frames)[i] = frame;
 		}
 	}


### PR DESCRIPTION
Fix translucent wielded node rendering.

Also, drop remains of bumpmapping support.

## To do

This PR is Ready for Review.

## How to test

Make sure various item and node types are rendered correctly when wielded.