### PR TITLE
SSCSM: Compress CSMs before sending to the client

### DIFF
--- a/.github/workflows/lua_lint.yml
+++ b/.github/workflows/lua_lint.yml
@@ -14,10 +14,10 @@ on:
 jobs:
   luacheck:
     name: "Builtin Luacheck and Unit Tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: leafo/gh-actions-lua@v9
+    - uses: actions/checkout@v4
+    - uses: leafo/gh-actions-lua@v10
       with:
         luaVersion: "5.1.5"
     - uses: leafo/gh-actions-luarocks@v4

--- a/builtin/client/sscsm.lua
+++ b/builtin/client/sscsm.lua
@@ -340,9 +340,9 @@ core.register_on_modchannel_message(function(channel_name, sender, message)
 		if first_char == "E" then
 			-- End of messages, decompress and execute
 			local compressed = core.decode_base64(table.concat(chunks))
-			local code = compressed and core.decompress(compressed)
-			if not code then return end
-			local files = code:split("\0")
+			local all_code = compressed and core.decompress(compressed)
+			if not all_code then return end
+			local files = all_code:split("\0")
 			for _, file in ipairs(files) do
 				local name, code = file:match("^([^\n]-)\n(.-)$")
 				if not name then return end

--- a/builtin/client/sscsm.lua
+++ b/builtin/client/sscsm.lua
@@ -325,7 +325,6 @@ core.register_on_modchannel_message(function(channel_name, sender, message)
 
 		-- Automatically leave on last CSM
 		if name == ":cleanup" then
-			print('leaving channel')
 			leave_mod_channel()
 		end
 	elseif channel_name == v2_channel_name then
@@ -358,6 +357,9 @@ core.register_on_modchannel_message(function(channel_name, sender, message)
 			end
 
 			leave_mod_channel()
+
+			-- No need to store the compressed chunks anymore
+			chunks = nil
 		end
 	end
 end)

--- a/builtin/client/sscsm.lua
+++ b/builtin/client/sscsm.lua
@@ -271,73 +271,115 @@ assert(env._raw.minetest.register_on_sending_chat_message ~=
 
 -- SSCSM functions
 -- When calling these from an SSCSM, make sure they exist first.
-local mod_channel
+local legacy_mod_channel, v2_mod_channel
 local loaded_sscsms = {}
-env:set("join_mod_channel", function()
-	if not mod_channel then
-		mod_channel = core.mod_channel_join("sscsm:exec_pipe")
+local function leave_mod_channel()
+	if legacy_mod_channel then
+		legacy_mod_channel:leave()
+		legacy_mod_channel = nil
 	end
-end)
-
-env:set("leave_mod_channel", function()
-	if mod_channel then
-		mod_channel:leave()
-		mod_channel = nil
+	if v2_mod_channel then
+		v2_mod_channel:leave()
+		v2_mod_channel = nil
 	end
-end)
+end
 
 env:set("set_error_handler", function(func)
 	handle_error = func
 end)
 
 -- exec() code sent by the server.
+local legacy_channel_name = "sscsm:exec_pipe"
+local chunks, v2_channel_name
 core.register_on_modchannel_message(function(channel_name, sender, message)
-	if channel_name ~= "sscsm:exec_pipe" or (sender and sender ~= "") then
+	if sender and sender ~= "" then
 		return
 	end
 
-	-- The first character is currently a version code, currently 0.
-	-- Do not change unless absolutely necessary.
-	local version = message:sub(1, 1)
-	local name, code
-	if version == "0" then
-		local s, e = message:find("\n")
-		if not s or not e then return end
-		local target = message:sub(2, s - 1)
-		if target ~= core.localplayer:get_name() then return end
-		message = message:sub(e + 1)
-		s, e = message:find("\n")
-		if not s or not e then return end
-		name = message:sub(1, s - 1)
-		code = message:sub(e + 1)
-	else
-		return
-	end
+	if channel_name == legacy_channel_name then
+		-- Legacy protocol
+		-- The first character is currently a version code, currently 0.
+		-- Do not change unless absolutely necessary.
+		local version = message:sub(1, 1)
+		local name, code
+		if version == "0" then
+			local s, e = message:find("\n")
+			if not s or not e then return end
+			local target = message:sub(2, s - 1)
+			if target ~= core.localplayer:get_name() then return end
+			message = message:sub(e + 1)
+			s, e = message:find("\n")
+			if not s or not e then return end
+			name = message:sub(1, s - 1)
+			code = message:sub(e + 1)
+		else
+			return
+		end
 
-	-- Don't load the same SSCSM twice
-	if not loaded_sscsms[name] then
-		core.log("action", "[SSCSM] Loading " .. name)
-		loaded_sscsms[name] = true
-		env:exec(code, name)
+		-- Don't load the same SSCSM twice
+		if not loaded_sscsms[name] then
+			core.log("info", "[SSCSM] Loading " .. name .. " (legacy protocol)")
+			loaded_sscsms[name] = true
+			env:exec(code, name)
+		end
+
+		-- Automatically leave on last CSM
+		if name == ":cleanup" then
+			print('leaving channel')
+			leave_mod_channel()
+		end
+	elseif channel_name == v2_channel_name then
+		-- New protocol: Compressed blob of code
+		-- C: Continue (more messages coming)
+		-- E: End (this is the last message)
+		local first_char = message:sub(1, 1)
+		if first_char ~= "C" and first_char ~= "E" then return end
+
+		chunks = chunks or {}
+		chunks[#chunks + 1] = message:sub(2)
+
+		if first_char == "E" then
+			-- End of messages, decompress and execute
+			local compressed = core.decode_base64(table.concat(chunks))
+			local code = compressed and core.decompress(compressed)
+			if not code then return end
+			local files = code:split("\0")
+			for _, file in ipairs(files) do
+				local name, code = file:match("^([^\n]-)\n(.-)$")
+				if not name then return end
+
+				if not loaded_sscsms[name] then
+					core.log("info", "[SSCSM] Loading " .. name .. " (v2 protocol)")
+					loaded_sscsms[name] = true
+					env:exec(code, name)
+				else
+					core.log("error", "[SSCSM] Attempt to load " .. name .. " twice")
+				end
+			end
+
+			leave_mod_channel()
+		end
 	end
 end)
 
 -- Send "0" when the "sscsm:exec_pipe" channel is first joined.
-local sent_request = false
+local sent_request = {}
 core.register_on_modchannel_signal(function(channel_name, signal)
-	if sent_request or channel_name ~= "sscsm:exec_pipe" then
+	if sent_request[channel_name] or (channel_name ~= legacy_channel_name and
+			channel_name ~= v2_channel_name) then
 		return
 	end
+
+	local mod_channel = channel_name == legacy_channel_name and legacy_mod_channel or v2_mod_channel
 
 	if signal == 0 then
 		env._raw.minetest.localplayer = core.localplayer
 		env._raw.minetest.camera = core.camera
 		env._raw.minetest.ui = copy(core.ui)
 		mod_channel:send_all("0")
-		sent_request = true
+		sent_request[channel_name] = true
 	elseif signal == 1 then
 		mod_channel:leave()
-		mod_channel = nil
 	end
 end)
 
@@ -357,7 +399,9 @@ local function attempt_to_join_mod_channel()
 		return
 	end
 
-	-- Join the mod channel
-	mod_channel = core.mod_channel_join("sscsm:exec_pipe")
+	-- Join the mod channels (the v2 channel must be joined first)
+	v2_channel_name = "sscsm:v2_" .. core.localplayer:get_name()
+	v2_mod_channel = core.mod_channel_join(v2_channel_name)
+	legacy_mod_channel = core.mod_channel_join(legacy_channel_name)
 end
 core.after(0, attempt_to_join_mod_channel)

--- a/builtin/game/sscsm/client.lua
+++ b/builtin/game/sscsm/client.lua
@@ -60,18 +60,6 @@ end
 
 core.global_exists = sscsm.global_exists
 
--- Check if join_mod_channel and leave_mod_channel exist.
-if sscsm.global_exists('join_mod_channel')
-		and sscsm.global_exists('leave_mod_channel') then
-	sscsm.join_mod_channel  = join_mod_channel
-	sscsm.leave_mod_channel = leave_mod_channel
-	join_mod_channel, leave_mod_channel = nil, nil
-else
-	local dummy = function() end
-	sscsm.join_mod_channel  = dummy
-	sscsm.leave_mod_channel = dummy
-end
-
 -- Add print()
 function print(...)
 	local msg = '[SSCSM] '
@@ -340,9 +328,15 @@ core.register_on_receiving_chat_message(function(message)
 end)
 
 sscsm.register_on_mods_loaded(function()
-	sscsm.leave_mod_channel()
 	sscsm.com_send('sscsm:com_test', {flags = sscsm.restriction_flags})
 end)
+
+-- Call leave_mod_channel for legacy clients
+if sscsm.global_exists('leave_mod_channel') then
+	sscsm.register_on_mods_loaded(leave_mod_channel)
+	join_mod_channel = nil
+	leave_mod_channel = nil
+end
 
 if core.global_exists("set_error_handler") then
 	set_error_handler(function(err)

--- a/builtin/game/sscsm/init.lua
+++ b/builtin/game/sscsm/init.lua
@@ -280,7 +280,7 @@ function sscsm.com_send(pname, channel, msg)
 	end
 
 	-- Compress long messages
-	if #msg > 4096 then
+	if #msg > 512 then
 		-- Chat messages can't contain binary data so base64 is used
 		local compressed_msg = minetest.encode_base64(minetest.compress(msg))
 

--- a/builtin/game/sscsm/init.lua
+++ b/builtin/game/sscsm/init.lua
@@ -43,7 +43,7 @@ end
 
 -- Register code
 sscsm.registered_csms = {}
-local csm_order = false
+local csm_order
 
 -- Recalculate the CSM loading order
 -- TODO: Make this nicer
@@ -71,7 +71,7 @@ local function recalc_csm_order()
 		for name2, u in pairs(unsatisfied) do
 			if u[name] then
 				u[name] = nil
-				if #u == 0 then
+				if not next(u) then
 					table.insert(staging, name2)
 				end
 			end
@@ -146,20 +146,77 @@ core.register_on_mods_loaded(recalc_csm_order)
 
 -- Handle players joining
 local has_sscsms = {}
-local mod_channel = core.mod_channel_join("sscsm:exec_pipe")
+local sscsms_sent = {}
+local v2_mod_channels = {}
+local legacy_mod_channel = core.mod_channel_join("sscsm:exec_pipe")
+local v2_chunk_size = 65530
 core.register_on_modchannel_message(function(channel_name, sender, message)
-	if channel_name ~= "sscsm:exec_pipe" or not sender or
-			not mod_channel:is_writeable() or message ~= "0" or
-			sender:find("\n") or has_sscsms[sender] then
-		return
-	end
-	core.log("info", "[SSCSM] Sending CSMs on request for " .. sender .. "...")
-	for _, name in ipairs(csm_order) do
-		local def = sscsm.registered_csms[name]
-		if not def.is_enabled_for or def.is_enabled_for(sender) then
-			mod_channel:send_all("0" .. sender .. "\n" .. name
-				.. "\n" .. sscsm.registered_csms[name].code)
+	if not sender or sscsms_sent[sender] or message ~= "0" then return end
+
+	local v2_channel = v2_mod_channels[sender]
+	if channel_name == "sscsm:exec_pipe" then
+		-- Legacy protocol (uncompressed)
+		if not legacy_mod_channel:is_writeable() or sender:find("\n") then
+			return
 		end
+
+		sscsms_sent[sender] = true
+		core.log("info", "[SSCSM] Sending CSMs on request for " .. sender ..
+			" (legacy protocol)...")
+		for _, name in ipairs(csm_order) do
+			local def = sscsm.registered_csms[name]
+			if not def.is_enabled_for or def.is_enabled_for(sender) then
+				legacy_mod_channel:send_all("0" .. sender .. "\n" .. name
+					.. "\n" .. def.code)
+			end
+		end
+	elseif channel_name == "sscsm:v2_" .. sender and v2_channel then
+		-- New protocol (compressed)
+		local blob = {}
+
+		for _, name in ipairs(csm_order) do
+			local def = sscsm.registered_csms[name]
+			if not def.is_enabled_for or def.is_enabled_for(sender) then
+				blob[#blob + 1] = name .. "\n" .. def.code
+			end
+		end
+
+		local compressed = core.encode_base64(core.compress(table.concat(blob, "\0")))
+
+		sscsms_sent[sender] = true
+		core.log("info", "[SSCSM] Sending CSMs on request for " .. sender ..
+			" (v2 protocol)...")
+		-- This is not optimal but the compressed code is probably only one or
+		-- two chunks anyway
+		while #compressed > v2_chunk_size do
+			v2_channel:send_all("C" .. compressed:sub(1, v2_chunk_size))
+			compressed = compressed:sub(v2_chunk_size + 1)
+		end
+		v2_channel:send_all("E" .. compressed)
+	end
+
+	-- No point staying in the v2 mod channel now that SSCSMs are sent
+	if v2_channel then
+		v2_channel:leave()
+		v2_mod_channels[sender] = nil
+	end
+end)
+
+core.register_on_joinplayer(function(player)
+	-- Join player-specific mod channels to avoid relaying messages to players
+	-- that don't need them
+	local name = player:get_player_name()
+	v2_mod_channels[name] = core.mod_channel_join("sscsm:v2_" .. name)
+end)
+
+core.register_on_leaveplayer(function(player)
+	local name = player:get_player_name()
+	has_sscsms[name] = nil
+
+	-- Leave the v2 mod channel
+	if v2_mod_channels[name] then
+		v2_mod_channels[name]:leave()
+		v2_mod_channels[name] = nil
 	end
 end)
 
@@ -320,10 +377,6 @@ end)
 function sscsm.has_sscsms_enabled(name)
 	return has_sscsms[name] or false
 end
-
-core.register_on_leaveplayer(function(player)
-	has_sscsms[player:get_player_name()] = nil
-end)
 
 function sscsm.com_send_all(channel, msg)
 	for name, _ in pairs(has_sscsms) do


### PR DESCRIPTION
This PR introduces a new SSCSM sending protocol. I've made it use one mod channel per player so that mod channel messages don't get sent to wrong players, as apparently client-to-server only mod channels don't actually exist so all mod channel messages get relayed to all clients in the mod channel. Malicious clients could still join another player's mod channel and see what code they get, but this doesn't give them anything they couldn't already get through other means.

This saves (very roughly) 60% of bandwidth sent when transferring CSMs (about 50 KB). Unfortunately I had to base64 encode the messages because the mod channel API can't handle binary data, but this doesn't seem to have impacted the bandwidth saving too badly. I also made it compress all the code together and minimise the number of mod channel messages sent, so the actual saved bandwidth might be larger due to less network protocol overhead.

This change is backwards compatible, both the server and client will handle SSCSMs using the legacy protocol if the V2 one isn't supported by either of them.

I also reduced the sscsm_com message length for the compression check, this is unrelated to the protocol change and could potentially be merged without the rest of this PR.

The CI is apparently broken, I'm not sure if it can be fixed easily