### PR TITLE
Always open pause menu in main thread

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4679,7 +4679,18 @@ void the_game(bool *kill,
 #ifdef __ANDROID__
 		porting::handleError("ModError", error_message);
 #endif
+	} catch (con::PeerNotFoundException &e) {
+			error_message = gettext("Connection error (timed out?)");
+			errorstream << error_message << std::endl;
 	}
+#ifdef NDEBUG
+	catch (std::exception &e) {
+		std::string error_message = "Some exception: \"";
+		error_message += e.what();
+		error_message += "\"";
+		errorstream << error_message << std::endl;
+	}
+#endif
 	game.shutdown();
 }
 


### PR DESCRIPTION
Also make sure that game.shutdown() is executed when exception occurs and it doesn't go directly to clientlauncher.