### PR TITLE
Some fixes for SDL device

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -215,33 +215,39 @@ void RenderingEngine::setResizable(bool resize)
 
 bool RenderingEngine::print_video_modes()
 {
-	IrrlichtDevice *nulldevice;
+	IrrlichtDevice *device = RenderingEngine::get_raw_device();
+	MyEventReceiver *receiver = nullptr;
+	bool is_null_device = false;
 
-	bool vsync = g_settings->getBool("vsync");
-	u16 fsaa = g_settings->getU16("fsaa");
-	MyEventReceiver *receiver = new MyEventReceiver();
+	if (!device) {
+		is_null_device = true;
 
-	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
-	params.DriverType = video::EDT_NULL;
-	params.WindowSize = core::dimension2d<u32>(640, 480);
-	params.Bits = 24;
-	params.AntiAlias = fsaa;
-	params.Fullscreen = false;
-	params.Stencilbuffer = false;
-	params.Vsync = vsync;
-	params.EventReceiver = receiver;
-	params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
+		bool vsync = g_settings->getBool("vsync");
+		u16 fsaa = g_settings->getU16("fsaa");
+		receiver = new MyEventReceiver();
 
-	nulldevice = createDeviceEx(params);
+		SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
+		params.DriverType = video::EDT_NULL;
+		params.WindowSize = core::dimension2d<u32>(640, 480);
+		params.Bits = 24;
+		params.AntiAlias = fsaa;
+		params.Fullscreen = false;
+		params.Stencilbuffer = false;
+		params.Vsync = vsync;
+		params.EventReceiver = receiver;
+		params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
 
-	if (!nulldevice) {
+		device = createDeviceEx(params);
+	}
+
+	if (!device) {
 		delete receiver;
 		return false;
 	}
 
 	std::cout << _("Available video modes (WxHxD):") << std::endl;
 
-	video::IVideoModeList *videomode_list = nulldevice->getVideoModeList();
+	video::IVideoModeList *videomode_list = device->getVideoModeList();
 
 	if (videomode_list != NULL) {
 		s32 videomode_count = videomode_list->getVideoModeCount();
@@ -261,8 +267,10 @@ bool RenderingEngine::print_video_modes()
 			  << videomode_depth << std::endl;
 	}
 
-	nulldevice->drop();
-	delete receiver;
+	if (is_null_device) {
+		device->drop();
+		delete receiver;
+	}
 
 	return videomode_list != NULL;
 }
@@ -740,11 +748,21 @@ void RenderingEngine::_draw_load_cleanup()
 
 std::vector<core::vector3d<u32>> RenderingEngine::getSupportedVideoModes()
 {
-	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);
-	sanity_check(nulldevice);
+	IrrlichtDevice *device = RenderingEngine::get_raw_device();
+	bool is_null_device = false;
+	sanity_check(device);
+
+	if (!device) {
+		device = createDevice(video::EDT_NULL);
+		is_null_device = true;
+	}
 
 	std::vector<core::vector3d<u32>> mlist;
-	video::IVideoModeList *modelist = nulldevice->getVideoModeList();
+
+	if (!device)
+		return mlist;
+
+	video::IVideoModeList *modelist = device->getVideoModeList();
 
 	s32 num_modes = modelist->getVideoModeCount();
 	for (s32 i = 0; i != num_modes; i++) {
@@ -753,7 +771,9 @@ std::vector<core::vector3d<u32>> RenderingEngine::getSupportedVideoModes()
 		mlist.emplace_back(mode_res.Width, mode_res.Height, mode_depth);
 	}
 
-	nulldevice->drop();
+	if (is_null_device)
+		device->drop();
+
 	return mlist;
 }
 
@@ -923,11 +943,22 @@ float RenderingEngine::getDisplayDensity()
 
 v2u32 RenderingEngine::getDisplaySize()
 {
-	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);
+	IrrlichtDevice *device = RenderingEngine::get_raw_device();
+	bool is_null_device = false;
+
+	if (!device) {
+		device = createDevice(video::EDT_NULL);
+		is_null_device = true;
+	}
+
+	if (!device)
+		return core::dimension2d<u32>(0, 0);
 
 	core::dimension2d<u32> deskres =
-			nulldevice->getVideoModeList()->getDesktopResolution();
-	nulldevice->drop();
+			device->getVideoModeList()->getDesktopResolution();
+
+	if (is_null_device)
+		device->drop();
 
 	return deskres;
 }

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -215,39 +215,33 @@ void RenderingEngine::setResizable(bool resize)
 
 bool RenderingEngine::print_video_modes()
 {
-	IrrlichtDevice *device = RenderingEngine::get_raw_device();
-	MyEventReceiver *receiver = nullptr;
-	bool is_null_device = false;
+	IrrlichtDevice *nulldevice;
 
-	if (!device) {
-		is_null_device = true;
+	bool vsync = g_settings->getBool("vsync");
+	u16 fsaa = g_settings->getU16("fsaa");
+	MyEventReceiver *receiver = new MyEventReceiver();
 
-		bool vsync = g_settings->getBool("vsync");
-		u16 fsaa = g_settings->getU16("fsaa");
-		receiver = new MyEventReceiver();
+	SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
+	params.DriverType = video::EDT_NULL;
+	params.WindowSize = core::dimension2d<u32>(640, 480);
+	params.Bits = 24;
+	params.AntiAlias = fsaa;
+	params.Fullscreen = false;
+	params.Stencilbuffer = false;
+	params.Vsync = vsync;
+	params.EventReceiver = receiver;
+	params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
 
-		SIrrlichtCreationParameters params = SIrrlichtCreationParameters();
-		params.DriverType = video::EDT_NULL;
-		params.WindowSize = core::dimension2d<u32>(640, 480);
-		params.Bits = 24;
-		params.AntiAlias = fsaa;
-		params.Fullscreen = false;
-		params.Stencilbuffer = false;
-		params.Vsync = vsync;
-		params.EventReceiver = receiver;
-		params.HighPrecisionFPU = g_settings->getBool("high_precision_fpu");
+	nulldevice = createDeviceEx(params);
 
-		device = createDeviceEx(params);
-	}
-
-	if (!device) {
+	if (!nulldevice) {
 		delete receiver;
 		return false;
 	}
 
 	std::cout << _("Available video modes (WxHxD):") << std::endl;
 
-	video::IVideoModeList *videomode_list = device->getVideoModeList();
+	video::IVideoModeList *videomode_list = nulldevice->getVideoModeList();
 
 	if (videomode_list != NULL) {
 		s32 videomode_count = videomode_list->getVideoModeCount();
@@ -267,10 +261,8 @@ bool RenderingEngine::print_video_modes()
 			  << videomode_depth << std::endl;
 	}
 
-	if (is_null_device) {
-		device->drop();
-		delete receiver;
-	}
+	nulldevice->drop();
+	delete receiver;
 
 	return videomode_list != NULL;
 }
@@ -748,21 +740,11 @@ void RenderingEngine::_draw_load_cleanup()
 
 std::vector<core::vector3d<u32>> RenderingEngine::getSupportedVideoModes()
 {
-	IrrlichtDevice *device = RenderingEngine::get_raw_device();
-	bool is_null_device = false;
-	sanity_check(device);
-
-	if (!device) {
-		device = createDevice(video::EDT_NULL);
-		is_null_device = true;
-	}
+	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);
+	sanity_check(nulldevice);
 
 	std::vector<core::vector3d<u32>> mlist;
-
-	if (!device)
-		return mlist;
-
-	video::IVideoModeList *modelist = device->getVideoModeList();
+	video::IVideoModeList *modelist = nulldevice->getVideoModeList();
 
 	s32 num_modes = modelist->getVideoModeCount();
 	for (s32 i = 0; i != num_modes; i++) {
@@ -771,9 +753,7 @@ std::vector<core::vector3d<u32>> RenderingEngine::getSupportedVideoModes()
 		mlist.emplace_back(mode_res.Width, mode_res.Height, mode_depth);
 	}
 
-	if (is_null_device)
-		device->drop();
-
+	nulldevice->drop();
 	return mlist;
 }
 
@@ -943,22 +923,11 @@ float RenderingEngine::getDisplayDensity()
 
 v2u32 RenderingEngine::getDisplaySize()
 {
-	IrrlichtDevice *device = RenderingEngine::get_raw_device();
-	bool is_null_device = false;
-
-	if (!device) {
-		device = createDevice(video::EDT_NULL);
-		is_null_device = true;
-	}
-
-	if (!device)
-		return core::dimension2d<u32>(0, 0);
+	IrrlichtDevice *nulldevice = createDevice(video::EDT_NULL);
 
 	core::dimension2d<u32> deskres =
-			device->getVideoModeList()->getDesktopResolution();
-
-	if (is_null_device)
-		device->drop();
+			nulldevice->getVideoModeList()->getDesktopResolution();
+	nulldevice->drop();
 
 	return deskres;
 }

--- a/src/gui/touchscreengui_mc.cpp
+++ b/src/gui/touchscreengui_mc.cpp
@@ -757,7 +757,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 		return false;
 
 	bool result = false;
-	s32 id = (unsigned int)event.TouchInput.ID;
+	u64 id = event.TouchInput.ID;
 	s32 x = event.TouchInput.X;
 	s32 y = event.TouchInput.Y;
 
@@ -841,7 +841,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 			}
 
 			if (!m_events[id]) {
-				if (m_camera.event_id == -1) {
+				if (m_camera.event_id == 0) {
 					m_events[id] = true;
 					m_camera.downtime = porting::getTimeMs();
 					m_camera.x = x;
@@ -861,7 +861,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 							new_state = STATE_DEFAULT;
 						}
 					}
-				} else if (m_camera_additional.event_id == -1) {
+				} else if (m_camera_additional.event_id == 0) {
 					m_events[id] = true;
 					m_camera_additional.downtime = porting::getTimeMs();
 					m_camera_additional.x = x;
@@ -873,7 +873,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 			}
 		}
 
-		if (m_current_state == STATE_EDITOR && !m_events[id] && m_editor.event_id == -1) {
+		if (m_current_state == STATE_EDITOR && !m_events[id] && m_editor.event_id == 0) {
 			for (auto button : m_buttons) {
 				if (button->state != STATE_DEFAULT)
 					continue;
@@ -994,7 +994,7 @@ bool TouchScreenGUI::preprocessEvent(const SEvent &event)
 		if (m_joystick.event_id == id)
 			m_joystick.reset(m_visible && m_current_state == STATE_DEFAULT);
 
-		if (m_camera.event_id == id && m_camera_additional.event_id != -1) {
+		if (m_camera.event_id == id && m_camera_additional.event_id != 0) {
 			m_camera.reset();
 			m_camera.event_id = m_camera_additional.event_id;
 			m_camera.x = m_camera_additional.x;
@@ -1450,7 +1450,7 @@ void TouchScreenGUI::step(float dtime)
 	if (m_current_state == STATE_OVERFLOW && m_overflow_close_schedule)
 		changeCurrentState(m_previous_state);
 
-	if (m_camera.event_id != -1 && (!m_camera.has_really_moved) &&
+	if (m_camera.event_id != 0 && (!m_camera.has_really_moved) &&
 			m_current_state == STATE_DEFAULT) {
 		u64 delta = porting::getDeltaMs(m_camera.downtime, porting::getTimeMs());
 		if (delta > MIN_DIG_TIME_MS) {
@@ -1459,7 +1459,7 @@ void TouchScreenGUI::step(float dtime)
 		}
 	}
 
-	if (m_camera_additional.event_id != -1 && (!m_camera_additional.has_really_moved) &&
+	if (m_camera_additional.event_id != 0 && (!m_camera_additional.has_really_moved) &&
 			m_current_state == STATE_DEFAULT) {
 		u64 delta = porting::getDeltaMs(m_camera_additional.downtime, porting::getTimeMs());
 		if (delta > MIN_DIG_TIME_MS) {

--- a/src/gui/touchscreengui_mc.cpp
+++ b/src/gui/touchscreengui_mc.cpp
@@ -2,8 +2,8 @@
 Copyright (C) 2014 sapier
 Copyright (C) 2018 srifqi, Muhammad Rifqi Priyo Susanto
 		<muhammadrifqipriyosusanto@gmail.com>
-Copyright (C) 2014-2025 Maksim Gamarnik [MoNTE48] Maksym48@pm.me
-Copyright (C) 2023-2025 Dawid Gan <deveee@gmail.com>
+Copyright (C) 2014-2026 Maksim Gamarnik [MoNTE48] Maksym48@pm.me
+Copyright (C) 2023-2026 Dawid Gan <deveee@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/gui/touchscreengui_mc.h
+++ b/src/gui/touchscreengui_mc.h
@@ -1,7 +1,7 @@
 /*
 Copyright (C) 2014 sapier
-Copyright (C) 2014-2025 Maksim Gamarnik [MoNTE48] Maksym48@pm.me
-Copyright (C) 2023-2025 Dawid Gan <deveee@gmail.com>
+Copyright (C) 2014-2026 Maksim Gamarnik [MoNTE48] Maksym48@pm.me
+Copyright (C) 2023-2026 Dawid Gan <deveee@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/src/gui/touchscreengui_mc.h
+++ b/src/gui/touchscreengui_mc.h
@@ -102,14 +102,14 @@ struct button_info
 	bool pressed = false;
 	bool floating = false;
 	bool inactive = false;
-	s32 event_id = -1;
+	u64 event_id = 0;
 	std::string image;
 	float aspect_ratio = -1;
 
 	void reset()
 	{
 		pressed = false;
-		event_id = -1;
+		event_id = 0;
 	}
 };
 
@@ -122,7 +122,7 @@ struct joystick_info
 	s16 move_forward = 0;
 	bool pressed = false;
 	bool released = false;
-	s32 event_id = -1;
+	u64 event_id = 0;
 
 	void reset(bool visible)
 	{
@@ -135,7 +135,7 @@ struct joystick_info
 		move_sideward = 0;
 		move_forward = 0;
 		pressed = false;
-		event_id = -1;
+		event_id = 0;
 	}
 };
 
@@ -165,7 +165,7 @@ struct camera_info
 	bool place_shootline = false;
 	s32 x = 0;
 	s32 y = 0;
-	s32 event_id = -1;
+	u64 event_id = 0;
 
 	void reset()
 	{
@@ -176,7 +176,7 @@ struct camera_info
 		place_shootline = false;
 		x = 0;
 		y = 0;
-		event_id = -1;
+		event_id = 0;
 	}
 };
 
@@ -200,7 +200,7 @@ struct editor_info
 	button_info *button = nullptr;
 	IGUIButton *guibutton = nullptr;
 	touch_gui_button_id button_id = unknown_id;
-	s32 event_id = -1;
+	u64 event_id = 0;
 	s32 x = 0;
 	s32 y = 0;
 	bool change_size = false;
@@ -213,7 +213,7 @@ struct editor_info
 		button = nullptr;
 		guibutton = nullptr;
 		button_id = unknown_id;
-		event_id = -1;
+		event_id = 0;
 		x = 0;
 		y = 0;
 	}

--- a/src/gui/touchscreengui_mc.h
+++ b/src/gui/touchscreengui_mc.h
@@ -249,7 +249,7 @@ public:
 
 	line3d<f32> getShootline()
 	{
-		if (m_camera_additional.event_id != -1 ||
+		if (m_camera_additional.event_id != 0 ||
 				m_camera_additional.place_shootline) {
 			m_camera_additional.place_shootline = false;
 			return m_camera_additional.shootline;


### PR DESCRIPTION
- Don't create null device when irrlicht device is already created
- SDL uses 64bit for touch input id. Also SDL3 uses 0 as invalid value