### PR TITLE
Fix model[] flickering on the first frame

### DIFF
--- a/src/gui/guiScene.cpp
+++ b/src/gui/guiScene.cpp
@@ -103,6 +103,16 @@ void GUIScene::draw()
 		m_cam->bindTargetAndRotation(true);
 	}
 
+	if (m_initial_rotation && m_mesh) {
+		m_cam->updateAbsolutePosition();
+		m_cam->updateMatrices();
+
+		rotateCamera(v3f(m_custom_rot.X, m_custom_rot.Y, 0.f));
+		calcOptimalDistance();
+
+		m_initial_rotation = false;
+	}
+
 	cameraLoop();
 
 	// Continuous rotation
@@ -110,13 +120,6 @@ void GUIScene::draw()
 		rotateCamera(v3f(0.f, -0.03f * (float)dtime_ms, 0.f));
 
 	m_smgr->drawAll();
-
-	if (m_initial_rotation && m_mesh) {
-		rotateCamera(v3f(m_custom_rot.X, m_custom_rot.Y, 0.f));
-		calcOptimalDistance();
-
-		m_initial_rotation = false;
-	}
 
 	m_driver->setViewPort(oldViewPort);
 }


### PR DESCRIPTION
Per the documentation of `updateMatrices()`:

```cpp
		//! Updates the view matrix and frustum without uploading the matrix to the driver.
		/** You need this when you want an up-to-date camera view matrix & frustum before the render() call.
		Usually you should call updateAbsolutePosition() before calling this.
		Despite it's function name, the projection matrix is not touched. */
		virtual void updateMatrices() = 0;
```

And `calcOptimalDistance` uses the frustum. I've moved it to above the draw call since we want to calculate & set the camera position correctly before drawing any frames.