### PR TITLE
Android: Remove chunksize setting

### DIFF
--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -563,7 +563,6 @@ void set_default_settings()
 		settings->setDefault("dedicated_server_step", "0.2");
 		settings->setDefault("abm_interval", "2.0");
 		settings->setDefault("nodetimer_interval", "0.4");
-		settings->setDefault("chunksize", "3");
 		settings->setDefault("arm_inertia", "false");
 		settings->setDefault("enable_particles", "false");
 	}


### PR DESCRIPTION
It has caused problems with Lua mapgens which assume that it's always 5. This change will only affect new worlds, existing worlds created on low memory devices will stay at 3 forever.

There is in theory more RAM usage during generation, but I doubt that will be very significant.

The larger chunks do, of course, take slightly longer to generate, but I don't think that will be an issue since the difference is almost always <10ms per chunk in my (very) rough testing, and it has to generate fewer chunks in total.