### PR TITLE
Fixed copying text with newlines from chat console.

### DIFF
--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -785,7 +785,7 @@ irr::core::stringc GUIChatConsole::getSelectedText()
 			for (unsigned int j = 0; j < line.fragments.size(); j++) {
 				const ChatFormattedFragment &fragment = line.fragments[j];
 
-				for (unsigned int k = 0; k < fragment.text.size(); k++) {
+				for (unsigned int k = 0; k <= fragment.text.size(); k++) {
 					if (!add_to_string &&
 							row == mark_begin_row_buf &&
 							i == real_mark_begin.line &&
@@ -793,26 +793,24 @@ irr::core::stringc GUIChatConsole::getSelectedText()
 							k == real_mark_begin.character) {
 						add_to_string = true;
 					}
-
 					if (add_to_string) {
 						if (row == mark_end_row_buf &&
 								i == real_mark_end.line &&
 								j == real_mark_end.fragment &&
 								k == real_mark_end.character) {
-
 							irr::core::stringc text_c;
 							text_c = wide_to_utf8(text.c_str()).c_str();
 							return text_c;
 						}
-
-						text += fragment.text.c_str()[k];
+						if (k < fragment.text.size())
+							text += fragment.text.c_str()[k];
 					}
 				}
 			}
+		}
 
-			if (row < mark_end_row_buf) {
-				text += L"\n";
-			}
+		if (add_to_string && row < mark_end_row_buf) {
+			text += L"\n";
 		}
 	}
 

--- a/src/gui/guiEditBox.cpp
+++ b/src/gui/guiEditBox.cpp
@@ -436,7 +436,7 @@ bool GUIEditBox::processKey(const SEvent &event)
 		} break;
 		case KEY_RIGHT: {
 			IGUIFont *font = getActiveFont();
-			s32 next_pos = font->getPrevClusterPos(Text, m_cursor_pos);
+			s32 next_pos = font->getNextClusterPos(Text, m_cursor_pos);
 
 			if (event.KeyInput.Shift) {
 				if (Text.size() > (u32)m_cursor_pos) {


### PR DESCRIPTION
It wasn't copying text when first selected line was empty. Also it was unnecessarily adding empty lines for very long lines with text warping.

Also fixed keyboard navigation in edit box.