### PR TITLE
Go to the mainmenu when an “OOM” occurs

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -353,6 +353,10 @@ void Client::step(float dtime)
 
 	m_time_of_day_update_timer += dtime;
 
+	// Mesh worker hit OOM: abort to the main menu to free the world.
+	if (m_mesh_update_thread.m_out_of_memory)
+		setFatalError("Out of memory");
+
 	ReceiveAll();
 
 	/*

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -353,9 +353,11 @@ void Client::step(float dtime)
 
 	m_time_of_day_update_timer += dtime;
 
+#if defined(__ANDROID__) || defined(__APPLE__)
 	// Mesh worker hit OOM: abort to the main menu to free the world.
 	if (m_mesh_update_thread.m_out_of_memory)
 		setFatalError("Out of memory");
+#endif
 
 	ReceiveAll();
 

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -287,7 +287,19 @@ void MeshUpdateThread::doUpdate()
 			sleep_ms(m_generation_interval);
 		ScopeProfiler sp(g_profiler, "Client: Mesh making (sum)");
 
+#if defined(__ANDROID__) || defined(__APPLE__)
+		MapBlockMesh *mesh_new;
+		try {
+			mesh_new = new MapBlockMesh(q->data, m_camera_offset);
+		} catch (const std::bad_alloc &) {
+			// OOM: signal Client::step to abort to the main menu.
+			m_out_of_memory = true;
+			delete q;
+			return;
+		}
+#else
 		MapBlockMesh *mesh_new = new MapBlockMesh(q->data, m_camera_offset);
+#endif
 
 		MeshUpdateResult r;
 		r.p = q->p;

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -118,6 +118,9 @@ public:
 	v3s16 m_camera_offset;
 	MutexedQueue<MeshUpdateResult> m_queue_out;
 
+	// Set on OOM by the worker; Client::step() aborts to the main menu.
+	bool m_out_of_memory = false;
+
 private:
 	MeshUpdateQueue m_queue_in;
 

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 
+#include <atomic>
 #include <ctime>
 #include <mutex>
 #include "mapblock_mesh.h"
@@ -119,7 +120,7 @@ public:
 	MutexedQueue<MeshUpdateResult> m_queue_out;
 
 	// Set on OOM by the worker; Client::step() aborts to the main menu.
-	bool m_out_of_memory = false;
+	std::atomic<bool> m_out_of_memory = false;
 
 private:
 	MeshUpdateQueue m_queue_in;

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -119,8 +119,10 @@ public:
 	v3s16 m_camera_offset;
 	MutexedQueue<MeshUpdateResult> m_queue_out;
 
+#if defined(__ANDROID__) || defined(__APPLE__)
 	// Set on OOM by the worker; Client::step() aborts to the main menu.
 	std::atomic<bool> m_out_of_memory = false;
+#endif
 
 private:
 	MeshUpdateQueue m_queue_in;

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -681,6 +681,9 @@ void *EmergeThread::run()
 		if (blockpos_over_max_limit(pos))
 			continue;
 
+#if defined(__ANDROID__) || defined(__APPLE__)
+		try {
+#endif
 		bool allow_gen = bedata.flags & BLOCK_EMERGE_ALLOW_GEN;
 		EMERGE_DBG_OUT("pos=" PP(pos) " allow_gen=" << allow_gen);
 
@@ -703,6 +706,13 @@ void *EmergeThread::run()
 
 		if (!modified_blocks.empty())
 			m_server->SetBlocksNotSent(modified_blocks);
+
+#if defined(__ANDROID__) || defined(__APPLE__)
+	} catch (const std::bad_alloc &) {
+		m_server->setAsyncFatalError("Out of memory");
+		break;
+	}
+#endif
 	}
 	} catch (VersionMismatchException &e) {
 		std::ostringstream err;


### PR DESCRIPTION
I have not verified that the exception handlers don't try and allocate more memory before freeing anything (I have looked very quickly and didn't see anything), but in the worst case it would just mean another `bad_alloc` exception.