### PR TITLE
Add core.change_password() CSM API

### DIFF
--- a/doc/client_lua_api.txt
+++ b/doc/client_lua_api.txt
@@ -851,6 +851,12 @@ Call these functions only at load time!
     * Returns [server info](#server-info).
 * `minetest.send_respawn()`
     * Sends a respawn request to the server.
+* `minetest.change_password(current_password, new_password)`
+    * Requests a password change to `new_password`.
+    * If `current_password` is a string, the server will reject the change if
+      it is incorrect.
+    * If `current_password` is `nil`, the client uses the password it logged in
+      with as the old password, so the caller does not need to know it.
 
 ### Storage API
 * `minetest.get_mod_storage()`:

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -241,6 +241,10 @@ public:
 	void clearOutChatQueue();
 	void sendChangePassword(const std::string &oldpassword,
 		const std::string &newpassword, const bool close_form = false);
+	void sendChangePassword(const std::string &newpassword)
+	{
+		sendChangePassword(m_password, newpassword, false);
+	}
 	void sendDamage(u16 damage);
 	void sendRespawn();
 	void sendReady();

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -486,6 +486,22 @@ int ModApiClient::l_texture_exists(lua_State *L)
 	return 1;
 }
 
+// change_password(current_password, new_password)
+int ModApiClient::l_change_password(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	std::string newpassword = readParam<std::string>(L, 2);
+
+	if (lua_isnil(L, 1)) {
+		getClient(L)->sendChangePassword(newpassword);
+	} else {
+		std::string currentpassword = readParam<std::string>(L, 1);
+		getClient(L)->sendChangePassword(currentpassword, newpassword, false);
+	}
+	return 0;
+}
+
 void ModApiClient::Initialize(lua_State *L, int top)
 {
 	API_FCT(get_current_modname);
@@ -517,4 +533,5 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_secret_key);
 	API_FCT(set_visible_controls);
 	API_FCT(texture_exists);
+	API_FCT(change_password);
 }

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -117,6 +117,9 @@ private:
 	// texture_exists(texture_name)
 	static int l_texture_exists(lua_State *L);
 
+	// change_password(current_password, new_password)
+	static int l_change_password(lua_State *L);
+
 public:
 	static void Initialize(lua_State *L, int top);
 };


### PR DESCRIPTION
Originally I had the idea of making the server accept a password change without knowing the old password, but this is simpler and works on MT servers too.

<sup>This is LLM-generated, though it is pretty trivial</sup>
